### PR TITLE
missing dependency & compute keyerror

### DIFF
--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -111,16 +111,17 @@ def compute(project_file):
         pickle.dump(basin_states, pkl_handler, protocol=pickle.HIGHEST_PROTOCOL)
 
     heads = ["NSE", "RMSE", "R2", "PBIAS"]
-    data = [
-        [stat, *[statistics[stat][k] for k in heads]]
-        for stat in statistics
-    ]
-    print(
-        tabulate(
-            data,
-            headers=['Basin', *heads], tablefmt='psql'
-        )
-    )
+    data = {key: [] for key in ('Root Node', *heads)}
+    for node in basin["root_node"]:
+        stat = statistics.get(node)
+        if stat is None:
+            continue
+
+        data['Root Node'].append(node)
+        for key in heads:
+            data[key].append(stat.get(key))
+
+    print(tabulate(data, headers='keys', tablefmt='psql'))
     with open(statistics_file,'w') as stat_file_write_buffer:
         json.dump(statistics, stat_file_write_buffer, indent=2)
     

--- a/scripts/tank_cmd.py
+++ b/scripts/tank_cmd.py
@@ -109,20 +109,18 @@ def compute(project_file):
 
     with open( project_dir / 'basin_states.pkl', 'wb') as pkl_handler:
         pickle.dump(basin_states, pkl_handler, protocol=pickle.HIGHEST_PROTOCOL)
-    
-     
-    print( 
-        tabulate(
-            [
-                ('NSE', statistics['BAHADURABAD']['NSE']),
-                ('RMSE', statistics['BAHADURABAD']['RMSE']),
-                ('R2', statistics['BAHADURABAD']['R2']),
-                ('PBIAS', statistics['BAHADURABAD']['PBIAS']),
-            ],
-            headers=['Statistics', 'BAHADURABAD'], tablefmt='psql'
-        ) 
-    )
 
+    heads = ["NSE", "RMSE", "R2", "PBIAS"]
+    data = [
+        [stat, *[statistics[stat][k] for k in heads]]
+        for stat in statistics
+    ]
+    print(
+        tabulate(
+            data,
+            headers=['Basin', *heads], tablefmt='psql'
+        )
+    )
     with open(statistics_file,'w') as stat_file_write_buffer:
         json.dump(statistics, stat_file_write_buffer, indent=2)
     

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ REQUIRED_PACKAGES = [
     'pathlib',
     'pytest',
     'python-dateutil',
-    'pytz'
+    'pytz',
+    'seaborn'
 ]
 
 KEYWORDS = [


### PR DESCRIPTION
This PR fixes 2 problems, 
## dependency error through pip
Installing through pip via 
```shell
pip install https://github.com/nzahasan/tank-model/zipball/master
```
and using 
```shell
tank_cmd.py --help
```
Produces the following
```python
Traceback (most recent call last):     
  File "U:\Programming\PycharmProjects\engineer_stuff\venv\Scripts\tank_cmd.py", line 18, in <module>
    import seaborn
ModuleNotFoundError: No module named 'seaborn'
```
## KeyError on compute command
using
```shell
tank_cmd.py compute -pf "<project file>"
```
would produce `KeyError: BAHADURABAD` when it finishes before saving. I assume BAHADURABAD is the original data that was used in the repository, so I changed it to be based on sub-basin set from the subbasin file.
Sample output looks as follows 
```
+------------+-----------+-----------+-------------+----------+
| Basin      |       NSE |      RMSE |          R2 |    PBIAS |
|------------+-----------+-----------+-------------+----------|
| JR-32      | -0.473036 |  5.07641  | 5.8996e-05  |  99.9999 |
| JR-36      | -0.411025 |  7.13107  | 7.86528e-05 |  99.9999 |
| JR-29      |  0.286019 |  1.10928  | 0.802523    |  56.6399 |
| JR-30      |  0.303259 |  2.63774  | 0.84493     |  56.0503 |
| JR-22      |  0.285221 |  3.47889  | 0.800422    |  56.6735 |
| JR-20      |  0.285283 |  1.36395  | 0.800422    |  56.6687 |
| JR-18      |  0.223459 |  1.97554  | 0.802103    |  55.918  |
+------------+-----------+-----------+-------------+----------+
```
