### PR TITLE
Fix tank storage calculation and improve Muskingum routing constraints

### DIFF
--- a/tank_core/channel_routing.py
+++ b/tank_core/channel_routing.py
@@ -29,8 +29,8 @@ def muskingum(in_flow:np.ndarray, del_t:float, k:float, x:float) -> np.ndarray:
     C1:float = (k*x+0.5 *del_t) / (k*(1-x)+0.5*del_t)
     C2:float = (k*(1-x) - 0.5*del_t) / (k*(1-x)+0.5*del_t)
 
-    # constraints check
-    if (C0+C1+C2) > 1 or x >0.5 or (del_t/k + x) > 1:
+    # constraints check: coefficients must be non-negative for stable routing
+    if C0 < 0 or C1 < 0 or C2 < 0 or x > 0.5:
         print("WARNING-MUSKINGUM-01: violates k, x constraints")
 
     # initial condition

--- a/tank_core/evapotranspiration.py
+++ b/tank_core/evapotranspiration.py
@@ -55,7 +55,7 @@ def ext_ra(date:datetime,lat:float) -> float:
 
     gsc     = 0.082                                   # global solar constant
 
-    _f = (2*pi*jul_day) / 365
+    _f = (2*pi*jul_day) / nday
     
     dr      = 1 + 0.033 * cos( _f )                   # inv. rel. distance Earth-Sun
 

--- a/tank_core/global_config.py
+++ b/tank_core/global_config.py
@@ -123,7 +123,7 @@ tank_ub:np.ndarray = np.array([
 # Channel - MUSKINGUM
 
 muskingum_param_bound:dict = {
-    "k" : {"min": 0, "max": 5},
+    "k" : {"min": 0.01, "max": 5},
     "x" : {"min": 0, "max": 0.5}
 
 }

--- a/tank_core/tank_basin.py
+++ b/tank_core/tank_basin.py
@@ -123,13 +123,13 @@ def tank_discharge(
         '''
         Tank storage of next step:
         --------------------------
-        tank_storage[t+1] = tank_storage[t] 
-                            + (precip[t+1] - evap[t+1])
+        tank_storage[t+1] = tank_storage[t]
+                            + (precip[t] - evap[t])
                             + bottom_outlet_flow_of_upper_tank[t]
-                            - (side_outlet_flow[t] + bottom_outlet_flow[t]) 
+                            - (side_outlet_flow[t] + bottom_outlet_flow[t])
         '''
         if t < (time_step - 1):
-            tank_storage[t+1,0] = tank_storage[t,0] + del_rf_et[t+1] - ( side_outlet_flow[t,0] + bottom_outlet_flow[t,0] )
+            tank_storage[t+1,0] = tank_storage[t,0] + del_rf_et[t] - ( side_outlet_flow[t,0] + bottom_outlet_flow[t,0] )
         
             tank_storage[t+1,1] = tank_storage[t,1] + bottom_outlet_flow[t,0] - ( side_outlet_flow[t,1] + bottom_outlet_flow[t,1] ) 
             


### PR DESCRIPTION
## Summary
This PR addresses several bugs and improvements in the hydrological modeling code:
1. Fixes an off-by-one error in tank storage calculations
2. Improves Muskingum channel routing constraint validation
3. Corrects the extraterrestrial radiation calculation
4. Adjusts Muskingum parameter bounds for numerical stability

## Key Changes

- **tank_basin.py**: Fixed tank storage update equation to use `del_rf_et[t]` instead of `del_rf_et[t+1]`, ensuring the correct precipitation and evapotranspiration values are applied at each time step. Also cleaned up trailing whitespace in comments.

- **channel_routing.py**: Improved Muskingum constraint checking by replacing the complex combined condition with explicit non-negativity checks for coefficients C0, C1, and C2. This ensures numerical stability of the routing algorithm and provides clearer validation logic.

- **evapotranspiration.py**: Fixed the extraterrestrial radiation calculation to use `nday` (number of days in year) instead of hardcoded `365`, improving accuracy for leap year handling.

- **global_config.py**: Adjusted the Muskingum parameter `k` minimum bound from `0` to `0.01` to prevent numerical issues and ensure physically meaningful routing parameters.

## Implementation Details

The tank storage fix corrects a temporal indexing issue where future precipitation/evapotranspiration values were being used instead of current values, which would have caused incorrect water balance calculations. The Muskingum improvements enhance numerical stability by explicitly checking coefficient constraints rather than relying on a combined inequality that could miss edge cases.

https://claude.ai/code/session_01KBMyDG5aSjvmzrD5DgMe9U